### PR TITLE
use valid country code

### DIFF
--- a/test/mockup/ssl.sls
+++ b/test/mockup/ssl.sls
@@ -8,7 +8,7 @@ test_mockup_ssl_create_ca:
     - ca_name: example_test_ca
     - days: 5
     - CN: 'example Test CA'
-    - C: MyCountry
+    - C: US
     - ST: MyState
     - L: MyCity
     - O: example Testing


### PR DESCRIPTION
current salt seems to choke on MyCountry

```
local:
       ----------
                 ID: test_mockup_ssl_create_ca
           Function: module.run
               Name: tls.create_ca
             Result: False
            Comment: Module function tls.create_ca threw an exception. Exception: [('asn1 encoding routines', 'ASN1_mbstring_ncopy', 'string too long')]
            Started: 21:05:09.437193
           Duration: 215.432 ms
            Changes:

```